### PR TITLE
Remove temporary workaround now that the runner fix is deployed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,9 +26,6 @@ jobs:
       - name: Install dependencies
         run: pip3 install -r requirements.txt
 
-      - name: Add Python bin to PATH
-        run: echo "/Library/Frameworks/Python.framework/Versions/Current/bin" >> $GITHUB_PATH
-
       - name: Run pylint
         run: |
           pip3 install pylint


### PR DESCRIPTION
Now that https://github.com/actions/runner-images/issues/6507 is fixed and deployed, remove manual add of python bin to PATH.