### PR TITLE
Delete downloaded CMake archive after extraction

### DIFF
--- a/install_cmake.py
+++ b/install_cmake.py
@@ -243,6 +243,12 @@ class CMakeInstall:
             sys.exit(1)
         subprocess.run(os.path.join(self.path, "cmake --version"), shell=True, check=True)
 
+        try:
+            if os.path.exists(self.archive):
+                os.remove(self.archive)
+        except OSError:
+            pass
+
 
     def set_path(self):
         if "GITHUB_PATH" in os.environ:


### PR DESCRIPTION
* Remove self.archive after successful extract and cmake --version verification
* Ignore missing-file / delete failures to keep reruns safe
* resolves https://github.com/ssrobins/install-cmake/issues/12